### PR TITLE
Odstranění návratového typu z PublicAccess

### DIFF
--- a/src/PublicAccess.php
+++ b/src/PublicAccess.php
@@ -4,5 +4,5 @@ namespace Pd\PublicAccess;
 
 interface PublicAccess extends \JsonSerializable
 {
-	public static function createFromStdObject(\stdClass $token): self;
+	public static function createFromStdObject(\stdClass $token);
 }


### PR DESCRIPTION
Díky odstranění návratového typu z interface, bude možné si v konkrétní implementaci otypovat metodu `createFromStdObject(\stdClass $token)` a díky tomu bude IDE hezky napovídat.