### PR TITLE
Lazy vytvoření klíčů

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,4 @@
 parameters:
+	bootstrapFiles:
+		- tests/phpstan/php7-compatibility.php
 	ignoreErrors:
-

--- a/src/Exception/CreateKeyException.php
+++ b/src/Exception/CreateKeyException.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace Pd\PublicAccess\Exception;
+
+class CreateKeyException extends PublicAccessException
+{
+
+}

--- a/src/Exception/PublicAccessException.php
+++ b/src/Exception/PublicAccessException.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace Pd\PublicAccess\Exception;
+
+class PublicAccessException extends \Exception
+{
+
+}

--- a/src/Tokenizer/AsymetricJwtTokenizer.php
+++ b/src/Tokenizer/AsymetricJwtTokenizer.php
@@ -9,14 +9,18 @@ final class AsymetricJwtTokenizer implements Tokenizer
 
 
 	/**
-	 * @var mixed
+	 * @var \OpenSSLAsymmetricKey|resource|NULL
 	 */
-	private $privateKey;
+	private $privateKey = NULL;
+
+	private string $privateKeyFile;
 
 	/**
-	 * @var mixed
+	 * @var \OpenSSLAsymmetricKey|resource|NULL
 	 */
-	private $publicKey;
+	private $publicKey = NULL;
+
+	private string $publicKeyFile;
 
 
 	public function __construct(
@@ -24,23 +28,69 @@ final class AsymetricJwtTokenizer implements Tokenizer
 		string $publicKey
 	)
 	{
-		$this->privateKey = \openssl_pkey_get_private('file://' . $privateKey);
-		$this->publicKey = \openssl_pkey_get_public('file://' . $publicKey);
+		$this->privateKeyFile = $privateKey;
+		$this->publicKeyFile = $publicKey;
 	}
 
 
+	/**
+	 * @throws \Pd\PublicAccess\Exception\CreateKeyException
+	 */
 	public function create(\Pd\PublicAccess\PublicAccess $object): string
 	{
-		return \Firebase\JWT\JWT::encode($object->jsonSerialize(), $this->privateKey, self::ALGORITHM);
+		return \Firebase\JWT\JWT::encode($object->jsonSerialize(), $this->privateKey(), self::ALGORITHM);
 	}
 
 
+	/**
+	 * @throws \Pd\PublicAccess\Exception\CreateKeyException
+	 */
 	public function decode(string $token): \stdClass
 	{
 		/** @var \stdClass $decode */
-		$decode = \Firebase\JWT\JWT::decode($token, new \Firebase\JWT\Key($this->publicKey, self::ALGORITHM));
+		$decode = \Firebase\JWT\JWT::decode($token, new \Firebase\JWT\Key($this->publicKey(), self::ALGORITHM));
 
 		return $decode;
+	}
+
+
+	/**
+	 * @return \OpenSSLAsymmetricKey|resource
+	 * @throws \Pd\PublicAccess\Exception\CreateKeyException
+	 */
+	private function privateKey()
+	{
+		if ($this->privateKey === NULL) {
+			$privateKey = \openssl_pkey_get_private('file://' . $this->privateKeyFile);
+
+			if ($privateKey === FALSE) {
+				throw new \Pd\PublicAccess\Exception\CreateKeyException('Invalid private key for JWT tokenizer');
+			}
+
+			$this->privateKey = $privateKey;
+		}
+
+		return $this->privateKey;
+	}
+
+
+	/**
+	 * @return \OpenSSLAsymmetricKey|resource
+	 * @throws \Pd\PublicAccess\Exception\CreateKeyException
+	 */
+	private function publicKey()
+	{
+		if ($this->publicKey === NULL) {
+			$publicKey = \openssl_pkey_get_public('file://' . $this->publicKeyFile);
+
+			if ($publicKey === FALSE) {
+				throw new \Pd\PublicAccess\Exception\CreateKeyException('Invalid public key for JWT tokenizer');
+			}
+
+			$this->publicKey = $publicKey;
+		}
+
+		return $this->publicKey;
 	}
 
 }

--- a/tests/phpstan/php7-compatibility.php
+++ b/tests/phpstan/php7-compatibility.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types = 1);
+
+if (PHP_VERSION_ID < 80000) {
+	class OpenSSLAsymmetricKey
+	{
+
+	}
+
+}


### PR DESCRIPTION
 - je to celkem náročná operace
 - nevytváříme tak zbytečně klíče, když je AsymetricJwtTokenizer uvedený jako závislost, ale při aktuálním běhu aplikace ho nevyužijeme